### PR TITLE
fix: Lower log level on stream writer closing

### DIFF
--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -20,7 +20,7 @@ use std::{env, mem};
 use time::format_description::well_known::Rfc2822;
 use time::OffsetDateTime;
 use tokio::io::{AsyncRead, AsyncReadExt};
-use tracing::{debug, error};
+use tracing::{debug, error, warn};
 use url::Url;
 
 static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
@@ -451,7 +451,7 @@ impl Bucket {
 
                     debug!("stream reader read {} bytes", size);
                     if let Err(err) = tx.send_async(Some(buf)).await {
-                        error!(
+                        warn!(
                             "Stream Writer has been closed before reader finished: {}",
                             err
                         );


### PR DESCRIPTION
When an upload fails, the stream writer will close with an error, which itself will return and log an error. No need to log another error when there is an underlying cause for the failure that should get passed along.