### PR TITLE
Fix no-default-features compilation, update dependencies and move dotenvy to a dev dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3-simple"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 rust-version = "1.88.0"
 authors = ["Sebastian Dobe <sebastiandobe@mailbox.org>"]
@@ -17,7 +17,7 @@ doctest = false
 [features]
 default = ["rustls"]
 
-rustls = ["reqwest/rustls"]
+rustls = ["reqwest/rustls", "dep:rustls-webpki"]
 rustls-no-provider = ["reqwest/rustls-no-provider"]
 
 native-tls = ["reqwest/native-tls"]
@@ -28,40 +28,33 @@ native-tls-vendored-no-alpn = ["reqwest/native-tls-vendored-no-alpn"]
 webpki-roots = ["dep:webpki-root-certs"]
 
 [dependencies]
-base64 = "0.22.0"
+base64 = "0.22.1"
 bytes = "1.11.1"
-dotenvy = "0.15"
-flume = "0.12"
-futures-util = "0.3.30"
+flume = "0.12.0"
+futures-util = "0.3.32"
 hex = "0.4.3"
-hmac = "0.12.1"
-http = "1.1.0"
+hmac = "0.13.0"
+http = "1.4.0"
 md5 = "0.8.0"
-percent-encoding = "2.3.1"
-quick-xml = { version = "0.39", features = ["serialize"] }
-reqwest = { version = "0.13", default-features = false, features = [
+percent-encoding = "2.3.2"
+quick-xml = { version = "0.39.4", features = ["serialize"] }
+reqwest = { version = "0.13.3", default-features = false, features = [
     "charset",
     "http2",
     "brotli",
     "stream",
 ] }
-serde = { version = "1.0.197", features = ["derive"] }
-# update blocked by hmac
-sha2 = "0.10.9"
-thiserror = "2"
+serde = { version = "1.0.228", features = ["derive"] }
+sha2 = "0.11.0"
+thiserror = "2.0.18"
 time = { version = "0.3.47", features = ["formatting", "macros"] }
-tokio = { version = "1.37.0", features = ["fs", "macros", "time"] }
-tracing = { version = "0.1.37", features = ["attributes"] }
-url = "2.5.0"
-webpki-root-certs = { version = "1.0.6", optional = true }
-
-# Necessary to fix security issues in current versions.
-aws-lc-sys = "0.39"
-aws-lc-rs = "1.16.2"
-quinn = "0.11.9"
-quinn-proto = "0.11.14"
-rustls-webpki = "0.103.10"
+tokio = { version = "1.52.3", features = ["fs", "macros", "time"] }
+tracing = { version = "0.1.44", features = ["attributes"] }
+url = "2.5.8"
+webpki-root-certs = { version = "1.0.7", optional = true }
+rustls-webpki = { version = "0.103.13", optional = true }
 
 [dev-dependencies]
-pretty_assertions = "1.4.0"
-tracing-test = "0.2.4"
+dotenvy = "0.15.7"
+pretty_assertions = "1.4.1"
+tracing-test = "0.2.6"

--- a/examples/streaming/src/main.rs
+++ b/examples/streaming/src/main.rs
@@ -1,8 +1,11 @@
+use std::os::unix::fs::MetadataExt;
+
 use futures_util::stream::StreamExt;
 use s3_simple::*;
-use std::os::unix::fs::MetadataExt;
-use tokio::fs::{self, File};
-use tokio::io::AsyncWriteExt;
+use tokio::{
+    fs::{self, File},
+    io::AsyncWriteExt,
+};
 
 #[tokio::main]
 async fn main() -> Result<(), S3Error> {

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -1,27 +1,29 @@
-use crate::command::{Command, CompleteMultipartUploadData, Part};
-use crate::constants::LONG_DATE_TIME;
-use crate::credentials::Credentials;
-use crate::error::S3Error;
-use crate::types::Multipart;
-use crate::types::{
-    HeadObjectResult, InitiateMultipartUploadResponse, ListBucketResult, PutStreamResponse,
+use std::{env, fmt::Write, mem, sync::OnceLock, time::Duration};
+
+use hmac::{Hmac, KeyInit};
+use http::{
+    header::{ACCEPT, AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE, DATE, HOST, RANGE},
+    HeaderMap, HeaderName, HeaderValue,
 };
-use crate::{md5_url_encode, signature, Region, S3Response, S3StatusCode};
-use hmac::Hmac;
-use http::header::{ACCEPT, AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE, DATE, HOST, RANGE};
-use http::{HeaderMap, HeaderName, HeaderValue};
 use reqwest::Response;
-use sha2::digest::Mac;
-use sha2::Sha256;
-use std::fmt::Write;
-use std::sync::OnceLock;
-use std::time::Duration;
-use std::{env, mem};
-use time::format_description::well_known::Rfc2822;
-use time::OffsetDateTime;
+use sha2::{digest::Mac, Sha256};
+use time::{format_description::well_known::Rfc2822, OffsetDateTime};
 use tokio::io::{AsyncRead, AsyncReadExt};
 use tracing::{debug, error, warn};
 use url::Url;
+
+use crate::{
+    command::{Command, CompleteMultipartUploadData, Part},
+    constants::LONG_DATE_TIME,
+    credentials::Credentials,
+    error::S3Error,
+    md5_url_encode, signature,
+    types::{
+        HeadObjectResult, InitiateMultipartUploadResponse, ListBucketResult, Multipart,
+        PutStreamResponse,
+    },
+    Region, S3Response, S3StatusCode,
+};
 
 static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
 
@@ -666,17 +668,29 @@ impl Bucket {
 
     fn get_client<'a>() -> &'a reqwest::Client {
         CLIENT.get_or_init(|| {
-            let danger_accept_invalid =
-                env::var("S3_DANGER_ALLOW_INSECURE").as_deref() == Ok("true");
-
             #[allow(unused_mut)]
             let mut builder = reqwest::Client::builder()
                 .brotli(true)
-                .tls_danger_accept_invalid_certs(danger_accept_invalid)
-                .tls_version_min(reqwest::tls::Version::TLS_1_2)
                 .connect_timeout(Duration::from_secs(10))
                 .tcp_keepalive(Duration::from_secs(30))
                 .pool_idle_timeout(Duration::from_secs(600));
+
+            #[cfg(any(
+                feature = "rustls",
+                feature = "rustls-no-provider",
+                feature = "native-tls",
+                feature = "native-tls-no-alpn",
+                feature = "native-tls-vendored",
+                feature = "native-tls-vendored-no-alpn"
+            ))]
+            {
+                let danger_accept_invalid =
+                    env::var("S3_DANGER_ALLOW_INSECURE").as_deref() == Ok("true");
+
+                builder = builder
+                    .tls_danger_accept_invalid_certs(danger_accept_invalid)
+                    .tls_version_min(reqwest::tls::Version::TLS_1_2);
+            }
 
             #[cfg(feature = "webpki-roots")]
             {
@@ -976,10 +990,11 @@ impl Bucket {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use pretty_assertions::assert_eq;
     use tokio::fs;
     use tracing_test::traced_test;
+
+    use super::*;
 
     #[traced_test]
     #[tokio::test]
@@ -1102,8 +1117,9 @@ mod tests {
     #[traced_test]
     #[tokio::test]
     async fn test_multipart() -> Result<(), S3Error> {
-        use futures_util::stream::StreamExt;
         use std::os::unix::fs::MetadataExt;
+
+        use futures_util::stream::StreamExt;
         use tokio::io::AsyncWriteExt;
 
         dotenvy::dotenv().ok().unwrap();

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,9 +1,10 @@
-use crate::constants::EMPTY_PAYLOAD_SHA;
-use crate::types::Multipart;
+use std::fmt;
+
 use http::HeaderMap;
 use serde::Serialize;
 use sha2::{Digest, Sha256};
-use std::fmt;
+
+use crate::{constants::EMPTY_PAYLOAD_SHA, types::Multipart};
 
 #[derive(Debug, Serialize)]
 pub struct Part {

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -1,8 +1,11 @@
 #![allow(dead_code)]
 
+use std::{
+    env,
+    fmt::{Debug, Formatter},
+};
+
 use crate::error::S3Error;
-use std::env;
-use std::fmt::{Debug, Formatter};
 
 #[derive(Debug, Clone)]
 pub struct AccessKeyId(pub String);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,9 +3,10 @@
 #![doc = include_str!("../README.md")]
 #![forbid(unsafe_code)]
 
-use base64::engine::general_purpose;
-use base64::Engine;
 use std::env;
+
+use base64::{engine::general_purpose, Engine};
+pub use reqwest::{Response as S3Response, StatusCode as S3StatusCode};
 
 /// S3 Bucket operations, your main entrypoint
 pub use crate::bucket::Bucket;
@@ -17,8 +18,6 @@ pub use crate::credentials::{AccessKeyId, AccessKeySecret, Credentials};
 pub use crate::error::S3Error;
 /// Specialized Response objects
 pub use crate::types::{HeadObjectResult, Object, PutStreamResponse};
-pub use reqwest::Response as S3Response;
-pub use reqwest::StatusCode as S3StatusCode;
 
 mod bucket;
 mod command;

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -1,16 +1,16 @@
-use crate::constants::LONG_DATE_TIME;
-use crate::credentials::{AccessKeyId, AccessKeySecret};
-use crate::error::S3Error;
-use crate::Region;
 use bytes::BytesMut;
-use hmac::Hmac;
+use hmac::{Hmac, KeyInit};
 use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
-use reqwest::header::HeaderMap;
-use reqwest::Url;
-use sha2::digest::Mac;
-use sha2::{Digest, Sha256};
-use time::macros::format_description;
-use time::OffsetDateTime;
+use reqwest::{header::HeaderMap, Url};
+use sha2::{digest::Mac, Digest, Sha256};
+use time::{macros::format_description, OffsetDateTime};
+
+use crate::{
+    constants::LONG_DATE_TIME,
+    credentials::{AccessKeyId, AccessKeySecret},
+    error::S3Error,
+    Region,
+};
 
 const SHORT_DATE: &[time::format_description::BorrowedFormatItem<'static>] =
     format_description!("[year][month][day]");
@@ -258,11 +258,12 @@ pub fn authorization_header(
 
 #[cfg(test)]
 mod tests {
-    use std::convert::TryInto;
-    use std::str;
+    use std::{convert::TryInto, str};
 
-    use http::header::{HeaderName, HOST, RANGE};
-    use http::HeaderMap;
+    use http::{
+        header::{HeaderName, HOST, RANGE},
+        HeaderMap,
+    };
     use time::Date;
     use url::Url;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,6 @@
-use serde::Deserialize;
 use std::str::FromStr;
+
+use serde::Deserialize;
 
 #[derive(Clone, Debug)]
 pub(crate) struct Multipart<'a> {


### PR DESCRIPTION
A lot of the vulnerability dependency updates are no longer relevant, `hmac` can be updated to `0.13` and a lot of other dependencies can also be bumped to avoid vulnerabilities, `dotenvy` is only used in tests and pretty much the exact same issue I fixed in https://github.com/sebadob/s3-simple/pull/22 has arisen again, hence this PR. Also I ran `cargo fmt`.