### PR TITLE
Remove direct aws-lc-sys dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,6 @@ url = "2.5.0"
 webpki-root-certs = { version = "1.0.6", optional = true }
 
 # Necessary to fix security issues in current versions.
-aws-lc-sys = "0.39"
 aws-lc-rs = "1.16.2"
 quinn = "0.11.9"
 quinn-proto = "0.11.14"


### PR DESCRIPTION
aws-lc-rs resolves to 1.18, which requires aws-lc-sys ^0.44. That can't unify with the direct ^0.39 requirement, so two copies of aws-lc-sys get built:
```
    $ cargo tree -d
    aws-lc-sys v0.39.1
    └── s3-simple
    [...]
    aws-lc-sys v0.44.0
    └── aws-lc-rs v1.18.0
```
The direct entry is also redundant as a minimal-versions fix, since aws-lc-rs 1.16.2 already requires aws-lc-sys ^0.39.0. With it removed, minimal-versions still resolves to aws-lc-sys 0.39.0, so the floor is unchanged and there's only one copy in the tree.